### PR TITLE
fix: second signature length calculation

### DIFF
--- a/lib/arkecosystem/crypto/crypto.rb
+++ b/lib/arkecosystem/crypto/crypto.rb
@@ -102,7 +102,7 @@ module ArkEcosystem
             transaction.delete(:second_signature)
           else
             # Second Signature
-            second_signature_length = signature[2, 2].to_i(16) + 2
+            second_signature_length = transaction[:second_signature][2, 2].to_i(16) + 2
             transaction[:second_signature] = transaction[:second_signature][0, second_signature_length * 2]
 
             # Multi Signature


### PR DESCRIPTION
Stumbled upon it while working on the Elixir AIP11 implementation.

For comparison PHP and Go:
```php
$length2 = intval(substr($transaction->secondSignature, 2, 2), 16) + 2;
```

```go
length2, _ := strconv.ParseInt(transaction.SecondSignature[2:4], 16, 64)
length2 += 2
```