### PR TITLE
fix: use correct integer size for timelock

### DIFF
--- a/lib/arkecosystem/crypto/deserialisers/timelock_transfer.rb
+++ b/lib/arkecosystem/crypto/deserialisers/timelock_transfer.rb
@@ -6,7 +6,7 @@ module ArkEcosystem
         def deserialise
           @transaction.amount = @binary.unpack("C#{@asset_offset / 2}Q<").last
           @transaction.timelocktype = @binary.unpack("C#{@asset_offset / 2 + 8}").last & 0xff
-          @transaction.timelock = @binary.unpack("C#{@asset_offset / 2 + 9}Q<").last
+          @transaction.timelock = @binary.unpack("C#{@asset_offset / 2 + 9}V").last
 
           recipient_id = @binary.unpack("H#{(@asset_offset / 2 + 13) * 2}H42").last
           @transaction.recipient_id = BTC::Base58.base58check_from_data([recipient_id].pack('H*'))

--- a/lib/arkecosystem/crypto/serialisers/timelock_transfer.rb
+++ b/lib/arkecosystem/crypto/serialisers/timelock_transfer.rb
@@ -6,7 +6,7 @@ module ArkEcosystem
         def serialise
           @bytes << [@transaction[:amount]].pack('Q<')
           @bytes << [@transaction[:timelocktype]].pack('h*')
-          @bytes << [@transaction[:timelock]].pack('Q<')
+          @bytes << [@transaction[:timelock]].pack('V')
 
           recipient_id = BTC::Base58.data_from_base58check(@transaction[:recipientId])
           recipient_id = BTC::Data.hex_from_data(recipient_id)


### PR DESCRIPTION
According to AIP11 timelock is 4 bytes and not 8 bytes.