### PR TITLE
 fix: skip recipient id in to_bytes for tx type 1 and 4 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.2.2
+
+### Fixed
+- Skip recipient id in `to_bytes` for type 1 and 4 transactions.
+
 ## 0.2.1 - 2018-07-31
 
 ### Fixed

--- a/lib/arkecosystem/crypto/transactions/transaction.rb
+++ b/lib/arkecosystem/crypto/transactions/transaction.rb
@@ -47,7 +47,9 @@ module ArkEcosystem
           bytes << [@timestamp].pack('V')
           bytes << [@sender_public_key].pack('H*')
 
-          bytes << if @recipient_id
+          skip_recipient_id = @type == ArkEcosystem::Crypto::Enums::Types::SECOND_SIGNATURE_REGISTRATION ||
+                        @type == ArkEcosystem::Crypto::Enums::Types::MULTI_SIGNATURE_REGISTRATION
+          bytes << if @recipient_id && !skip_recipient_id
           BTC::Base58.data_from_base58check(@recipient_id)
           else
             [].pack('x21')

--- a/spec/crypto/transactions/deserializer/delegate_registration_spec.rb
+++ b/spec/crypto/transactions/deserializer/delegate_registration_spec.rb
@@ -15,6 +15,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::DelegateRegistration
       expect(actual.amount).to eq(transaction.data.amount)
       expect(actual.id).to eq(transaction.data.id)
       expect(actual.asset[:delegate][:username]).to eq(transaction.data.asset.delegate.username)
+      expect(actual.verify).to eq(true)
     end
 
     it 'should be ok if signed with a second passphrase' do
@@ -33,6 +34,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::DelegateRegistration
       expect(actual.amount).to eq(transaction.data.amount)
       expect(actual.id).to eq(transaction.data.id)
       expect(actual.asset[:delegate][:username]).to eq(transaction.data.asset.delegate.username)
+      expect(actual.verify).to eq(true)
     end
   end
 end

--- a/spec/crypto/transactions/deserializer/multi_signature_registration_spec.rb
+++ b/spec/crypto/transactions/deserializer/multi_signature_registration_spec.rb
@@ -19,6 +19,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::MultiSignatureRegist
       expect(actual.asset[:multisignature][:keysgroup]).to eq(transaction.data.asset.multisignature.keysgroup)
       expect(actual.asset[:multisignature][:min]).to eq(transaction.data.asset.multisignature.min)
       expect(actual.asset[:multisignature][:lifetime]).to eq(transaction.data.asset.multisignature.lifetime)
+      expect(actual.verify).to eq(true)
     end
   end
 end

--- a/spec/crypto/transactions/deserializer/second_signature_registration_spec.rb
+++ b/spec/crypto/transactions/deserializer/second_signature_registration_spec.rb
@@ -15,6 +15,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::SecondSignatureRegis
       expect(actual.amount).to eq(transaction.data.amount)
       expect(actual.id).to eq(transaction.data.id)
       expect(actual.asset[:signature][:public_key]).to eq(transaction.data.asset.signature.publicKey)
+      expect(actual.verify).to eq(true)
 
       # special case as the type 1 transaction itself has no recipientId
       expect(actual.recipient_id).to eq(ArkEcosystem::Crypto::Identities::Address.from_public_key(actual.sender_public_key, actual.network))

--- a/spec/crypto/transactions/deserializer/transfer_spec.rb
+++ b/spec/crypto/transactions/deserializer/transfer_spec.rb
@@ -18,6 +18,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::Transfer do
       expect(actual.signature).to eq(transaction.data.signature)
       expect(actual.vendor_field).to eq(transaction.data.vendorField)
       expect(actual.id).to eq(transaction.data.id)
+      expect(actual.verify).to eq(true)
     end
 
     it 'should be ok if signed with a second passphrase' do
@@ -39,6 +40,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::Transfer do
       expect(actual.sign_signature).to eq(transaction.data.signSignature)
       expect(actual.vendor_field).to eq(transaction.data.vendorField)
       expect(actual.id).to eq(transaction.data.id)
+      expect(actual.verify).to eq(true)
     end
 
     it 'should be ok if signed with a passphrase and vendor field' do
@@ -58,6 +60,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::Transfer do
       expect(actual.signature).to eq(transaction.data.signature)
       expect(actual.vendor_field).to eq(transaction.data.vendorField)
       expect(actual.id).to eq(transaction.data.id)
+      expect(actual.verify).to eq(true)
     end
 
     it 'should be ok if signed with a second passphrase and vendor field' do
@@ -78,6 +81,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::Transfer do
       expect(actual.sign_signature).to eq(transaction.data.signSignature)
       expect(actual.vendor_field).to eq(transaction.data.vendorField)
       expect(actual.id).to eq(transaction.data.id)
+      expect(actual.verify).to eq(true)
     end
 
     it 'should be ok if signed with a passphrase and vendor field hex' do
@@ -97,6 +101,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::Transfer do
       expect(actual.recipient_id).to eq(transaction.data.recipientId)
       expect(actual.signature).to eq(transaction.data.signature)
       expect(actual.id).to eq(transaction.data.id)
+      expect(actual.verify).to eq(true)
     end
 
     it 'should be ok if signed with a second passphrase and vendor field hex' do
@@ -117,6 +122,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::Transfer do
       expect(actual.signature).to eq(transaction.data.signature)
       expect(actual.sign_signature).to eq(transaction.data.signSignature)
       expect(actual.id).to eq(transaction.data.id)
+      expect(actual.verify).to eq(true)
     end
   end
 end

--- a/spec/crypto/transactions/deserializer/vote_spec.rb
+++ b/spec/crypto/transactions/deserializer/vote_spec.rb
@@ -16,6 +16,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::Vote do
       expect(actual.recipient_id).to eq(transaction.data.recipientId)
       expect(actual.id).to eq(transaction.data.id)
       expect(actual.asset[:votes]).to eq(transaction.data.asset.votes)
+      expect(actual.verify).to eq(true)
     end
 
     it 'should be ok if signed with a second passphrase' do
@@ -35,6 +36,7 @@ describe ArkEcosystem::Crypto::Transactions::Deserializers::Vote do
       expect(actual.recipient_id).to eq(transaction.data.recipientId)
       expect(actual.id).to eq(transaction.data.id)
       expect(actual.asset[:votes]).to eq(transaction.data.asset.votes)
+      expect(actual.verify).to eq(true)
     end
   end
 end


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
In second signature and multi signature transactions the recipient id is not supposed to be included in the signature/id calculation. Add an additional check to `to_bytes` to explicitely exclude the recipientId. This also allows such transactions to be verified, even if the recipientId is set.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
<!--