### PR TITLE
refactor: moving to_params and to_dict inside base builder class

### DIFF
--- a/lib/arkecosystem/crypto/transactions/builder/base.rb
+++ b/lib/arkecosystem/crypto/transactions/builder/base.rb
@@ -46,6 +46,35 @@ module ArkEcosystem
           def second_verify(second_public_key)
             @transaction.second_verify(second_public_key)
           end
+
+          def to_params
+            {
+              type: @transaction.type,
+              amount: @transaction.amount,
+              fee: @transaction.fee,
+              vendorField: @transaction.vendor_field,
+              timestamp: @transaction.timestamp,
+              recipientId: @transaction.recipient_id,
+              senderPublicKey: @transaction.sender_public_key,
+              signature: @transaction.signature,
+              id: @transaction.id
+            }.tap do |h|
+              h[:asset] = @transaction.asset.deep_transform_keys { |key| snake_case_to_camel_case(key) } if @transaction.asset.any?
+              h[:signSignature] = @transaction.sign_signature if @transaction.sign_signature
+            end
+          end
+
+          def to_json
+            to_params.to_json
+          end
+
+          private
+
+          def snake_case_to_camel_case(string)
+            string.to_s.split('_').enum_for(:each_with_index).collect do |s, index|
+              index.zero? ? s : s.capitalize
+            end.join
+          end
         end
       end
     end

--- a/lib/arkecosystem/crypto/transactions/builder/base.rb
+++ b/lib/arkecosystem/crypto/transactions/builder/base.rb
@@ -50,31 +50,21 @@ module ArkEcosystem
           def to_params
             {
               type: @transaction.type,
-              amount: @transaction.amount,
               fee: @transaction.fee,
+              senderPublicKey: @transaction.sender_public_key,
+              recipientId: @transaction.recipient_id,
+              amount: @transaction.amount,
               vendorField: @transaction.vendor_field,
               timestamp: @transaction.timestamp,
-              recipientId: @transaction.recipient_id,
-              senderPublicKey: @transaction.sender_public_key,
-              signature: @transaction.signature,
-              id: @transaction.id
-            }.tap do |h|
-              h[:asset] = @transaction.asset.deep_transform_keys { |key| snake_case_to_camel_case(key) } if @transaction.asset.any?
-              h[:signSignature] = @transaction.sign_signature if @transaction.sign_signature
-            end
+              asset: @transaction.asset
+            }
+
           end
 
           def to_json
             to_params.to_json
           end
 
-          private
-
-          def snake_case_to_camel_case(string)
-            string.to_s.split('_').enum_for(:each_with_index).collect do |s, index|
-              index.zero? ? s : s.capitalize
-            end.join
-          end
         end
       end
     end

--- a/lib/arkecosystem/crypto/transactions/transaction.rb
+++ b/lib/arkecosystem/crypto/transactions/transaction.rb
@@ -165,6 +165,35 @@ module ArkEcosystem
         def deserialize(serialized)
           ArkEcosystem::Crypto::Transactions::Deserializer.new(serialized).deserialize
         end
+
+        def to_params
+          {
+            type: type,
+            amount: amount,
+            fee: fee,
+            vendorField: vendor_field,
+            timestamp: timestamp,
+            recipientId: recipient_id,
+            senderPublicKey: sender_public_key,
+            signature: signature,
+            id: id
+          }.tap do |h|
+            h[:asset] = asset.deep_transform_keys { |key| snake_case_to_camel_case(key) } if asset.any?
+            h[:signSignature] = sign_signature if sign_signature
+          end
+        end
+
+        def to_json
+          to_params.to_json
+        end
+
+        private
+
+        def snake_case_to_camel_case(string)
+          string.to_s.split('_').enum_for(:each_with_index).collect do |s, index|
+            index.zero? ? s : s.capitalize
+          end.join
+        end
       end
     end
   end

--- a/lib/arkecosystem/crypto/transactions/transaction.rb
+++ b/lib/arkecosystem/crypto/transactions/transaction.rb
@@ -165,35 +165,6 @@ module ArkEcosystem
         def deserialize(serialized)
           ArkEcosystem::Crypto::Transactions::Deserializer.new(serialized).deserialize
         end
-
-        def to_params
-          {
-            type: type,
-            amount: amount,
-            fee: fee,
-            vendorField: vendor_field,
-            timestamp: timestamp,
-            recipientId: recipient_id,
-            senderPublicKey: sender_public_key,
-            signature: signature,
-            id: id
-          }.tap do |h|
-            h[:asset] = asset.deep_transform_keys { |key| snake_case_to_camel_case(key) } if asset.any?
-            h[:signSignature] = sign_signature if sign_signature
-          end
-        end
-
-        def to_json
-          to_params.to_json
-        end
-
-        private
-
-        def snake_case_to_camel_case(string)
-          string.to_s.split('_').enum_for(:each_with_index).collect do |s, index|
-            index.zero? ? s : s.capitalize
-          end.join
-        end
       end
     end
   end


### PR DESCRIPTION
## Proposed changes
Looking at the other crypto libs like for example [python](https://github.com/ArkEcosystem/python-crypto/blob/master/crypto/transactions/builder/base.py) I see that it's done that way so I think it would be better for consistency and also ease of use to follow the same pattern here.

## Types of changes

- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)

## Checklist

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/developers/guidelines/contributing.html) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)